### PR TITLE
Remove remaining email links

### DIFF
--- a/site/about.html
+++ b/site/about.html
@@ -78,7 +78,7 @@ As Gold Standard for fitting the US states’ %ILI, we use the best stable estim
 </p>
          <p class="text_header"><i class="fa fa-list"></i> Information Sources Currently Used by ILI-Nearby</p>
 <p class="text_content">
-Our method can readily incorporate any additional information sources: Electronic Health Records, relevant retail sales (e.g. thermometers), crowdsourced reports, etc.  If you would like to contribute an information source or have an idea for a new potential source, please <a href="mailto:roni@cs.cmu.edu">contact us</a>!
+Our method can readily incorporate any additional information sources: Electronic Health Records, relevant retail sales (e.g. thermometers), crowdsourced reports, etc.  If you would like to contribute an information source or have an idea for a new potential source, please <a href="https://docs.google.com/forms/d/e/1FAIpQLScqgT1fKZr5VWBfsaSp-DNaN03aV6EoZU4YljIzHJ1Wl_zmtg/viewform">contact us</a>!
 </P>
          <p class="text_content">
             <ul>
@@ -135,10 +135,10 @@ The Archetype is a nonparametric Kalman Filter-based forecasting system built by
         </p>
  
  <p class="text_content">
-The sensor-fusion approach to nowcasting was developed and implemented by <a href="mailto:dfarrow0@gmail.com">David Farrow</a> as part of his <a href="http://delphi.midas.cs.cmu.edu/~dfarrow/thesis.pdf">2016 PhD thesis</a>, under the supervision of <a href="http://www.cs.cmu.edu/~roni/">Roni Rosenfeld</a>.  It forms the backend of ILI-Nearby.
+The sensor-fusion approach to nowcasting was developed and implemented by David Farrow as part of his <a href="http://delphi.midas.cs.cmu.edu/~dfarrow/thesis.pdf">2016 PhD thesis</a>, under the supervision of <a href="http://www.cs.cmu.edu/~roni/">Roni Rosenfeld</a>.  It forms the backend of ILI-Nearby.
  </p>
  <p class="text_content">
-The graphic interface to ILI-Nearby was initially designed and implemented by <a href="mailto:dfarrow0@gmail.com">David Farrow</a> in October 2016.  It was further developed by <a href="mailto:ziruiw@andrew.cmu.edu">Zirui (Edward) Wang</a>. 
+The graphic interface to ILI-Nearby was initially designed and implemented by David Farrow in October 2016.  It was further developed by Zirui (Edward) Wang. 
  </p>
  <p class="text_content">
 We are grateful to Google (Google Trends team), Johns Hopkins Social Media and Health Research Group, the Wikimedia Foundation, CDC Influenza Division (Epidemiology and Prevention Branch), and the Health Departments of many US states for giving us access to their data.

--- a/site/index.html
+++ b/site/index.html
@@ -12,7 +12,7 @@
     <div class="pages">
       <div class="page p1">
         <div class="announcement">
-          <h2><i class="fa fa-warning"></i>Note: This system is designed to nowcast ILI driven by seasonal influenza and is NOT designed to nowcast ILI during the COVID-19 pandemic. We are only keeping it running as others may be relying on it. For COVID-19 tracking, please see <a href="https://delphi.cmu.edu/covidcast">COVIDcast</a>.
+          <h2><i class="fa fa-warning"></i>Note: This system was designed to nowcast ILI under pre-COVID-pandemic conditions. The arrival of COVID has dramatically changed the meaning of ILI to the point where it's not clear how ILI should be interpreted. We are only keeping ILI Nearby running as others may be relying on it. For COVID-19 tracking, please see <a href="https://delphi.cmu.edu/covidcast">COVIDcast</a>. For further questions on ILI Nearby, please <a href="https://docs.google.com/forms/d/e/1FAIpQLScqgT1fKZr5VWBfsaSp-DNaN03aV6EoZU4YljIzHJ1Wl_zmtg/viewform">contact us</a>.
             <a title="Hide warning" class="close fa fa-close" aria-hidden="true" href="#"></a>
           </h2>
         </div>

--- a/site/index.html
+++ b/site/index.html
@@ -12,7 +12,7 @@
     <div class="pages">
       <div class="page p1">
         <div class="announcement">
-          <h2><i class="fa fa-warning"></i>Note: The measure of %ILI has lost its original meaning with the arrival of COVID-19 and the resulting changes in healthcare seeking behavior. This system is no longer being maintained, and many of the underlying data sources may no longer be working. We are only keeping ILI Nearby running as others may be relying on it. For COVID-19 tracking, please see <a href="https://delphi.cmu.edu/covidcast">COVIDcast</a>. For further questions on ILI Nearby, please <a href="https://docs.google.com/forms/d/e/1FAIpQLScqgT1fKZr5VWBfsaSp-DNaN03aV6EoZU4YljIzHJ1Wl_zmtg/viewform">contact us</a>.
+          <h2><i class="fa fa-warning"></i>Note: The measure of %ILI has lost its original meaning with the arrival of COVID-19 and the resulting changes in healthcare seeking behavior. ILI Nearby is no longer being maintained, and many of the underlying data sources may no longer be working. We are only leaving it running as others may be relying on it. For COVID-19 tracking, please see <a href="https://delphi.cmu.edu/covidcast">COVIDcast</a>. For further questions on ILI Nearby, please <a href="https://docs.google.com/forms/d/e/1FAIpQLScqgT1fKZr5VWBfsaSp-DNaN03aV6EoZU4YljIzHJ1Wl_zmtg/viewform">contact us</a>.
             <a title="Hide warning" class="close fa fa-close" aria-hidden="true" href="#"></a>
           </h2>
         </div>

--- a/site/index.html
+++ b/site/index.html
@@ -12,7 +12,7 @@
     <div class="pages">
       <div class="page p1">
         <div class="announcement">
-          <h2><i class="fa fa-warning"></i>Note: This system was designed to nowcast ILI under pre-COVID-pandemic conditions. The arrival of COVID has dramatically changed the meaning of ILI to the point where it's not clear how ILI should be interpreted. We are only keeping ILI Nearby running as others may be relying on it. For COVID-19 tracking, please see <a href="https://delphi.cmu.edu/covidcast">COVIDcast</a>. For further questions on ILI Nearby, please <a href="https://docs.google.com/forms/d/e/1FAIpQLScqgT1fKZr5VWBfsaSp-DNaN03aV6EoZU4YljIzHJ1Wl_zmtg/viewform">contact us</a>.
+          <h2><i class="fa fa-warning"></i>Note: The measure of %ILI has lost its original meaning with the arrival of COVID-19 and the resulting changes in healthcare seeking behavior. This system is no longer being maintained, and many of the underlying data sources may no longer be working. We are only keeping ILI Nearby running as others may be relying on it. For COVID-19 tracking, please see <a href="https://delphi.cmu.edu/covidcast">COVIDcast</a>. For further questions on ILI Nearby, please <a href="https://docs.google.com/forms/d/e/1FAIpQLScqgT1fKZr5VWBfsaSp-DNaN03aV6EoZU4YljIzHJ1Wl_zmtg/viewform">contact us</a>.
             <a title="Hide warning" class="close fa fa-close" aria-hidden="true" href="#"></a>
           </h2>
         </div>


### PR DESCRIPTION
People keep emailing alumni instead of using the actual contact link, so let's remove that option